### PR TITLE
Feature  checkout functionality

### DIFF
--- a/src/main/git-handler.js
+++ b/src/main/git-handler.js
@@ -120,44 +120,36 @@ async function checkWorkingDirectoryStatus(folderPath) {
 }
 
 /**
- * Restore project to a specific commit
+ * Restore project to a specific commit (leaves files uncommitted in working directory)
  * @param {string} folderPath - Path to the git repository
  * @param {string} commitHash - Hash of commit to restore to
- * @param {boolean} autoCommit - Whether to automatically commit after restore
  * @returns {Promise<{success: boolean, error?: string}>}
  */
-async function restoreCommit(folderPath, commitHash, autoCommit = true) {
+async function restoreCommit(folderPath, commitHash) {
   try {
-    // Check for uncommitted changes
-    const status = await checkWorkingDirectoryStatus(folderPath);
-
-    if (status.hasChanges) {
-      return {
-        success: false,
-        error: 'You have uncommitted changes. Please commit or discard them first.',
-        uncommittedFiles: status.files
-      };
-    }
-
-    // Restore files from the target commit
+    // Restore files from the target commit (doesn't create a commit)
     await execPromise(`git checkout ${commitHash} -- .`, { cwd: folderPath });
-    console.log(`Restored files from commit ${commitHash}`);
-
-    if (autoCommit) {
-      // Create a new commit with the restored state
-      const shortHash = commitHash.substring(0, 7);
-      const commitMessage = `Restored to version ${shortHash}`;
-
-      const commitResult = await createCommit(folderPath, commitMessage);
-
-      if (!commitResult.success) {
-        return { success: false, error: `Restored files but failed to commit: ${commitResult.error}` };
-      }
-    }
+    console.log(`Restored files from commit ${commitHash} (uncommitted)`);
 
     return { success: true };
   } catch (error) {
     console.error('Error restoring commit:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Discard uncommitted changes in working directory
+ * @param {string} folderPath - Path to the git repository
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+async function discardChanges(folderPath) {
+  try {
+    await execPromise('git checkout -- .', { cwd: folderPath });
+    console.log('Discarded uncommitted changes');
+    return { success: true };
+  } catch (error) {
+    console.error('Error discarding changes:', error);
     return { success: false, error: error.message };
   }
 }
@@ -201,4 +193,4 @@ async function getCommitHistory(folderPath, limit = 50) {
   }
 }
 
-module.exports = { initializeGitRepository, createCommit, getCommitHistory, restoreCommit, checkWorkingDirectoryStatus };
+module.exports = { initializeGitRepository, createCommit, getCommitHistory, restoreCommit, checkWorkingDirectoryStatus, discardChanges };

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -64,6 +64,36 @@ h2 {
   margin-bottom: 8px;
   border-radius: 4px;
   border-left: 3px solid #57a53f;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.commit-content {
+  flex: 1;
+}
+
+.commit-actions {
+  margin-left: 15px;
+}
+
+.restore-btn {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  background-color: #57a53f;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.restore-btn:hover {
+  background-color: #6bc04a;
+}
+
+.restore-btn:active {
+  background-color: #4a8a35;
 }
 
 .commit-message {


### PR DESCRIPTION
When user clicks "Restore", the app now:

Step 1: Check for uncommitted changes
- Uses git status --porcelain to detect modifications

Step 2: If changes exist, show dialog with 3 options:
- Cancel: Don't restore, keep working on current version
- Discard Changes: Throw away current changes and restore
- Commit Changes: Auto-commits with message like "Work in progress before restoring to abc1234", then restores

Step 3: Restore files (after handling uncommitted changes)
- Runs git checkout <hash> -- .
- Leaves files uncommitted in working directory

Step 4: Show success message
"Project files restored successfully!