### PR TITLE
Parser improvements

### DIFF
--- a/parser/als_parser.py
+++ b/parser/als_parser.py
@@ -1,13 +1,15 @@
 import gzip
+import json
+import sys
 from xml.etree import ElementTree as ET
 from pathlib import Path
 
 from collections import Counter
-from typing import Dict
+from typing import Dict, Optional
 
-als_project_path = "C:/MUSIC onli®/PROJECT FILES/2026 FLP/01 JANUARY FLP/school kid @onliwakeup @madd.maks Project/school kid @onliwakeup @madd.maks.als"
 
-def open_als_xml(path:Path) -> ET.ElementTree:
+def open_als_xml(path: Path) -> ET.ElementTree:
+    """Open an ALS file from disk (handles both gzipped and raw XML)."""
     try:
         with gzip.open(path, 'rb') as f:
             return ET.parse(f)
@@ -15,16 +17,20 @@ def open_als_xml(path:Path) -> ET.ElementTree:
         with open(path, 'rb') as f:
             return ET.parse(f)
 
-test = open_als_xml(Path(als_project_path))
+
+def parse_als_from_string(xml_content: str) -> ET.ElementTree:
+    """Parse ALS XML content from a string (already decompressed)."""
+    root = ET.fromstring(xml_content)
+    tree = ET.ElementTree(root)
+    return tree
 
 # print(test)
 
-def als_inspect(path: Path) -> Dict[str, int]:
+def als_inspect(tree: ET.ElementTree) -> Dict[str, int]:
     """
     Produce a rough frequency summary of XML element paths to guide schema mapping.
     Safe to run on any ALS without knowing its exact schema.
     """
-    tree = open_als_xml(path)
     root = tree.getroot()
     counter: Counter[str] = Counter()
 
@@ -38,8 +44,7 @@ def als_inspect(path: Path) -> Dict[str, int]:
     walk(root, "")
     return dict(counter)
                         
-def parse_als_with_values(file_path):
-    tree = open_als_xml(file_path)
+def parse_als_with_values(tree: ET.ElementTree):
     root = tree.getroot()
     
     def extract_with_values(element, path="", level=0):
@@ -61,8 +66,7 @@ def parse_als_with_values(file_path):
     
     extract_with_values(root)
     
-def extract_midi_notes(file_path):
-    tree = open_als_xml(file_path)
+def extract_midi_notes(tree: ET.ElementTree):
     
     # Find all MIDI notes
     notes = tree.findall(".//MidiNoteEvent")
@@ -80,9 +84,8 @@ def extract_midi_notes(file_path):
     
     return midi_data
 
-def count_notes_per_track(file_path):
+def count_notes_per_track(tree: ET.ElementTree):
     """Count the number of MIDI notes in each track."""
-    tree = open_als_xml(file_path)
     track_note_counts = []
     
     # Find all MIDI tracks
@@ -102,31 +105,43 @@ def count_notes_per_track(file_path):
     
     return track_note_counts
 
-def extract_tempo(file_path):
-    tree = open_als_xml(file_path)
+def extract_tempo(tree: ET.ElementTree):
     tempo_element = tree.find(".//Tempo/Manual")
     return float(tempo_element.get('Value')) if tempo_element is not None else 120.0
 
-def get_device_name(device_element):
+def get_device_info(device_element):
     """
-    Resolve the device name. If it's a plugin, try to get the plugin name.
+    Resolve the device name and type.
+    Returns a dict with 'name' and 'type'.
     """
+    name = device_element.tag
+    dev_type = "native"
+    
+    # Check for Plugin info
     # VST2
     vst = device_element.find(".//PluginDesc/VstPluginInfo/PlugName")
     if vst is not None and vst.get('Value'):
-        return vst.get('Value')
+        name = vst.get('Value')
+        dev_type = "vst2"
     
     # VST3
     vst3 = device_element.find(".//PluginDesc/Vst3PluginInfo/Name")
     if vst3 is not None and vst3.get('Value'):
-        return vst3.get('Value')
+        name = vst3.get('Value')
+        dev_type = "vst3"
 
     # AU
     au = device_element.find(".//PluginDesc/AuPluginInfo/Name")
     if au is not None and au.get('Value'):
-        return au.get('Value')
+        name = au.get('Value')
+        dev_type = "au"
         
-    return device_element.tag
+    # Heuristic for instrument vs effect could go here, but relying on format for now
+    # or simple XML tag checks if needed.
+    return {'name': name, 'type': dev_type}
+
+def get_device_name(device_element):
+    return get_device_info(device_element)['name']
 
 
 def get_clip_names(track_element):
@@ -165,8 +180,7 @@ def get_clip_names(track_element):
             
     return unique
 
-def extract_master_track_info(file_path):
-    tree = open_als_xml(file_path)
+def extract_master_track_info(tree: ET.ElementTree):
     # Check for MainTrack (Live 12+) or MasterTrack (older versions)
     master_track = tree.find(".//MainTrack")
     if master_track is None:
@@ -183,14 +197,14 @@ def extract_master_track_info(file_path):
     devices_container = master_track.find(".//Devices")
     if devices_container is not None:
         for device in devices_container:
-            devices.append(get_device_name(device))
+                    devices.append(get_device_info(device))
             
     return {
+        'type': 'Master',
         'devices': devices
     }
 
-def extract_track_info(file_path):
-    tree = open_als_xml(file_path)
+def extract_track_info(tree: ET.ElementTree):
     tracks = []
     
     # Check all track types: MidiTrack, AudioTrack, ReturnTrack
@@ -213,7 +227,7 @@ def extract_track_info(file_path):
             devices_container = track.find(".//Devices")
             if devices_container is not None:
                 for device in devices_container:
-                    devices.append(get_device_name(device))
+                    devices.append(get_device_info(device))
 
             # Extract Clips
             clips = get_clip_names(track)
@@ -225,16 +239,16 @@ def extract_track_info(file_path):
                 'devices': devices,
                 'clips': clips
             }
+
             tracks.append(track_data)
     
     return tracks
 
-def extract_plugin_names(file_path):
+def extract_plugin_names(tree: ET.ElementTree):
     """
     Extract the names of all third-party plugins (VST/AU) used in the project.
     Returns a list of unique plugin names with their format and vendor.
     """
-    tree = open_als_xml(file_path)
     plugins = []
     
     # Search in all track types including MainTrack/MasterTrack
@@ -290,58 +304,50 @@ def extract_plugin_names(file_path):
     
     return plugins
 
+def parse_als_to_json(tree: ET.ElementTree, project_name: str = "Unknown") -> dict:
+    """
+    Parse an ALS ElementTree and return a dictionary with project data.
+    """
+    # Gather data
+    tempo = extract_tempo(tree)
+    master_info = extract_master_track_info(tree)
+    raw_tracks = extract_track_info(tree)
+    plugins = extract_plugin_names(tree)
+
+    # Process tracks into categories
+    midi_tracks = [t for t in raw_tracks if t['type'] == 'MidiTrack']
+    audio_tracks = [t for t in raw_tracks if t['type'] == 'AudioTrack']
+    return_tracks = [t for t in raw_tracks if t['type'] == 'ReturnTrack']
+
+    # Build final dictionary
+    project_data = {
+        "project_name": project_name,
+        "tempo": tempo,
+        "tracks": {
+            "master": master_info if master_info else {"type": "Master", "devices": []},
+            "midi_tracks": midi_tracks,
+            "audio_tracks": audio_tracks,
+            "return_tracks": return_tracks
+        },
+        "third_party_vsts": plugins
+    }
+
+    return project_data
+
+
 if __name__ == "__main__":
-    file_path = Path(als_project_path)
-    
-    print("\n" + "="*60)
-    print(f"ABLETON PROJECT SUMMARY: {file_path.name}")
-    print("="*60 + "\n")
+    project_name = "Unknown"
 
-    # 1. General Info
-    tempo = extract_tempo(file_path)
-    print(f"► TEMPO: {tempo} BPM")
-    
-    master = extract_master_track_info(file_path)
-    print("MASTER TRACK:")
-    if master:
-        devs = ", ".join(master['devices']) if master['devices'] else "--"
-        print(f"devices: {devs}\n")
+    if len(sys.argv) > 1:
+        # File path provided as argument
+        file_path = Path(sys.argv[1])
+        project_name = file_path.name
+        tree = open_als_xml(file_path)
     else:
-        print("devices: (Not found)\n")
+        # Read from stdin (already decompressed XML from git show)
+        xml_content = sys.stdin.read()
+        tree = parse_als_from_string(xml_content)
 
-    # 2. Tracks
-    print("► TRACKS STRUCTURE:")
-    print(f"{'#':<4} {'Type':<12} {'Name':<30} {'Devices'}")
-    print("-" * 80)
-    
-    tracks = extract_track_info(file_path)
-    note_counts = count_notes_per_track(file_path)
-    
-    midi_track_index = 0
-    
-    for i, track in enumerate(tracks, 1):
-        name = track['name'] if track['name'] else "(Untitled)"
-        t_type = track['type']
-        devices = ", ".join(track['devices']) if track['devices'] else "-"
-        
-        extra_info = ""
-        if t_type == 'MidiTrack':
-            if midi_track_index < len(note_counts):
-                count = note_counts[midi_track_index]['note_count']
-                extra_info = f"[{count} notes]"
-                midi_track_index += 1
-        
-        print(f"{i:<4} {t_type:<12} {name:<30} {devices} {extra_info}") 
-
-    print("\n")
-
-    # 3. Plugins
-    print("► THIRD-PARTY PLUGINS:")
-    plugins = extract_plugin_names(file_path)
-    if not plugins:
-        print("  No third-party plugins found.")
-    else:
-        for p in plugins:
-            print(f"  • {p['name']} [{p['format']}]")
-            
-    print("\n" + "="*60)
+    # Parse and output JSON
+    project_data = parse_als_to_json(tree, project_name)
+    print(json.dumps(project_data, indent=2))

--- a/parser/als_parser.py
+++ b/parser/als_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from collections import Counter
 from typing import Dict
 
-als_project_path = "C:/Users/sebas/Documents/! FINAL YEAR/PROJECT/ableton-folders-test-cases/demo Project/demo.als"
+als_project_path = "C:/MUSIC onli®/PROJECT FILES/2026 FLP/01 JANUARY FLP/school kid @onliwakeup @madd.maks Project/school kid @onliwakeup @madd.maks.als"
 
 def open_als_xml(path:Path) -> ET.ElementTree:
     try:
@@ -107,6 +107,88 @@ def extract_tempo(file_path):
     tempo_element = tree.find(".//Tempo/Manual")
     return float(tempo_element.get('Value')) if tempo_element is not None else 120.0
 
+def get_device_name(device_element):
+    """
+    Resolve the device name. If it's a plugin, try to get the plugin name.
+    """
+    # VST2
+    vst = device_element.find(".//PluginDesc/VstPluginInfo/PlugName")
+    if vst is not None and vst.get('Value'):
+        return vst.get('Value')
+    
+    # VST3
+    vst3 = device_element.find(".//PluginDesc/Vst3PluginInfo/Name")
+    if vst3 is not None and vst3.get('Value'):
+        return vst3.get('Value')
+
+    # AU
+    au = device_element.find(".//PluginDesc/AuPluginInfo/Name")
+    if au is not None and au.get('Value'):
+        return au.get('Value')
+        
+    return device_element.tag
+
+
+def get_clip_names(track_element):
+    """
+    Extract names of all clips (Session and Arrangement) in the track.
+    Returns a list of unique clip names found.
+    """
+    clip_names = []
+    
+    # helper to check name nodes
+    def _extract_name(node):
+        # Try UserName first
+        user = node.find(".//Name/UserName")
+        if user is not None and user.get('Value'):
+            return user.get('Value')
+        # Then EffectiveName
+        eff = node.find(".//Name/EffectiveName")
+        if eff is not None and eff.get('Value'):
+            return eff.get('Value')
+        return None
+
+    # Search for MidiClip and AudioClip elements
+    for clip in track_element.findall(".//MidiClip") + track_element.findall(".//AudioClip"):
+        name = _extract_name(clip)
+        if name:
+            clip_names.append(name)
+            
+    # Return unique names to avoid clutter if loop is repeated
+    # Preserve order
+    seen = set()
+    unique = []
+    for c in clip_names:
+        if c not in seen:
+            unique.append(c)
+            seen.add(c)
+            
+    return unique
+
+def extract_master_track_info(file_path):
+    tree = open_als_xml(file_path)
+    # Check for MainTrack (Live 12+) or MasterTrack (older versions)
+    master_track = tree.find(".//MainTrack")
+    if master_track is None:
+        master_track = tree.find(".//MasterTrack")
+    
+    if master_track is None:
+        return None
+        
+    devices = []
+    # Note: Structure might be slightly deeper or different in newer versions
+    # Debug output showed: Ableton/LiveSet/MainTrack/DeviceChain/DeviceChain/Devices/...
+    
+    # Try looking for Devices container recursively inside the master track
+    devices_container = master_track.find(".//Devices")
+    if devices_container is not None:
+        for device in devices_container:
+            devices.append(get_device_name(device))
+            
+    return {
+        'devices': devices
+    }
+
 def extract_track_info(file_path):
     tree = open_als_xml(file_path)
     tracks = []
@@ -114,12 +196,34 @@ def extract_track_info(file_path):
     # Check all track types: MidiTrack, AudioTrack, ReturnTrack
     for track_type in [".//MidiTrack", ".//AudioTrack", ".//ReturnTrack"]:
         for track in tree.findall(track_type):
-            track_name = track.find(".//Name/UserName")
+            # Try UserName (custom name) first
+            track_name_elem = track.find(".//Name/UserName")
+            track_name_val = track_name_elem.get('Value') if track_name_elem is not None else ""
+
+            # If UserName is empty, try EffectiveName (default/displayed name)
+            if not track_name_val:
+                effective_name_elem = track.find(".//Name/EffectiveName")
+                if effective_name_elem is not None:
+                    track_name_val = effective_name_elem.get('Value')
+
+            devices = []
+            # Find the main device chain. 
+            # Instead of a fixed path, look for the first <Devices> element.
+            # This is usually the track's main device chain.
+            devices_container = track.find(".//Devices")
+            if devices_container is not None:
+                for device in devices_container:
+                    devices.append(get_device_name(device))
+
+            # Extract Clips
+            clips = get_clip_names(track)
+
             track_data = {
-                'name': track_name.get('Value') if track_name is not None else 'Untitled',
+                'name': track_name_val if track_name_val else 'Untitled',
                 'type': track_type.split('/')[-1],  # Get track type name
                 'color': track.find(".//Color").get('Value') if track.find(".//Color") is not None else None,
-                'devices': [device.tag for device in track.findall(".//DeviceChain/DeviceChain/Devices/*")]
+                'devices': devices,
+                'clips': clips
             }
             tracks.append(track_data)
     
@@ -133,8 +237,8 @@ def extract_plugin_names(file_path):
     tree = open_als_xml(file_path)
     plugins = []
     
-    # Search in all track types
-    for track_type in [".//MidiTrack", ".//AudioTrack", ".//ReturnTrack", ".//MasterTrack"]:
+    # Search in all track types including MainTrack/MasterTrack
+    for track_type in [".//MidiTrack", ".//AudioTrack", ".//ReturnTrack", ".//MasterTrack", ".//MainTrack"]:
         tracks = tree.findall(track_type)
         
         for track in tracks:
@@ -153,7 +257,6 @@ def extract_plugin_names(file_path):
                     plugin_info = {
                         'name': plugin_name_elem.get('Value') if plugin_name_elem is not None else 'Unknown VST',
                         'format': 'VST',
-                        'vendor': vendor_elem.get('Value') if vendor_elem is not None else 'Unknown'
                     }
                 
                 # Check for VST3 plugin
@@ -165,7 +268,6 @@ def extract_plugin_names(file_path):
                     plugin_info = {
                         'name': plugin_name_elem.get('Value') if plugin_name_elem is not None else 'Unknown VST3',
                         'format': 'VST3',
-                        'vendor': vendor_elem.get('Value') if vendor_elem is not None else 'Unknown'
                     }
                 
                 # Check for Audio Unit plugin
@@ -177,7 +279,6 @@ def extract_plugin_names(file_path):
                     plugin_info = {
                         'name': au_name_elem.get('Value') if au_name_elem is not None else 'Unknown AU',
                         'format': 'Audio Unit',
-                        'vendor': manufacturer_elem.get('Value') if manufacturer_elem is not None else 'Unknown'
                     }
                 
                 # Add plugin if found
@@ -198,7 +299,15 @@ if __name__ == "__main__":
 
     # 1. General Info
     tempo = extract_tempo(file_path)
-    print(f"► TEMPO: {tempo} BPM\n")
+    print(f"► TEMPO: {tempo} BPM")
+    
+    master = extract_master_track_info(file_path)
+    print("MASTER TRACK:")
+    if master:
+        devs = ", ".join(master['devices']) if master['devices'] else "--"
+        print(f"devices: {devs}\n")
+    else:
+        print("devices: (Not found)\n")
 
     # 2. Tracks
     print("► TRACKS STRUCTURE:")
@@ -222,7 +331,7 @@ if __name__ == "__main__":
                 extra_info = f"[{count} notes]"
                 midi_track_index += 1
         
-        print(f"{i:<4} {t_type:<12} {name:<30} {devices} {extra_info}")
+        print(f"{i:<4} {t_type:<12} {name:<30} {devices} {extra_info}") 
 
     print("\n")
 
@@ -233,6 +342,6 @@ if __name__ == "__main__":
         print("  No third-party plugins found.")
     else:
         for p in plugins:
-            print(f"  • {p['name']} ({p['vendor']}) [{p['format']}]")
+            print(f"  • {p['name']} [{p['format']}]")
             
     print("\n" + "="*60)

--- a/src/main/git-handler.js
+++ b/src/main/git-handler.js
@@ -193,4 +193,71 @@ async function getCommitHistory(folderPath, limit = 50) {
   }
 }
 
-module.exports = { initializeGitRepository, createCommit, getCommitHistory, restoreCommit, checkWorkingDirectoryStatus, discardChanges };
+/**
+ * Find the .als file in a project folder
+ * @param {string} folderPath - Path to the project folder
+ * @returns {Promise<{success: boolean, alsPath?: string, alsName?: string, error?: string}>}
+ */
+async function findAlsFile(folderPath) {
+  try {
+    const files = await fs.readdir(folderPath);
+    const alsFile = files.find(file => path.extname(file).toLowerCase() === '.als');
+
+    if (alsFile) {
+      return {
+        success: true,
+        alsPath: alsFile,  // Relative path (just filename)
+        alsName: alsFile
+      };
+    }
+
+    return { success: false, error: 'No .als file found in project' };
+  } catch (error) {
+    console.error('Error finding ALS file:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Get file content from a specific commit
+ * Uses git show to retrieve file content at a specific commit hash.
+ * Note: With zcat filter configured, .als files are stored uncompressed,
+ * so git show returns the raw XML.
+ *
+ * @param {string} folderPath - Path to the git repository
+ * @param {string} commitHash - Hash of the commit
+ * @param {string} filePath - Path to the file (relative to repo root)
+ * @returns {Promise<{success: boolean, content?: string, error?: string}>}
+ */
+async function getFileAtCommit(folderPath, commitHash, filePath) {
+  try {
+    // Use git show to get file content at specific commit
+    // maxBuffer increased for large ALS files
+    const { stdout } = await execPromise(
+      `git show ${commitHash}:"${filePath}"`,
+      {
+        cwd: folderPath,
+        maxBuffer: 50 * 1024 * 1024  // 50MB buffer for large files
+      }
+    );
+
+    return {
+      success: true,
+      content: stdout
+    };
+  } catch (error) {
+    console.error('Error getting file at commit:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+module.exports = {
+  initializeGitRepository,
+  createCommit,
+  getCommitHistory,
+  restoreCommit,
+  checkWorkingDirectoryStatus,
+  discardChanges,
+  findAlsFile,
+  getFileAtCommit
+};

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -1,7 +1,17 @@
 const { ipcMain, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs').promises;
-const { initializeGitRepository, createCommit, getCommitHistory, restoreCommit, checkWorkingDirectoryStatus, discardChanges } = require('./git-handler');
+const {
+  initializeGitRepository,
+  createCommit,
+  getCommitHistory,
+  restoreCommit,
+  checkWorkingDirectoryStatus,
+  discardChanges,
+  findAlsFile,
+  getFileAtCommit
+} = require('./git-handler');
+const { parseAlsContent } = require('./parser-handler');
 
 // Store the current project path
 let currentProjectPath = null;
@@ -156,6 +166,51 @@ function registerIpcHandlers() {
     }
 
     return restoreResult;
+  });
+
+  // Handle parsing ALS file from a specific commit
+  ipcMain.handle('parse-commit', async (event, commitHash) => {
+    if (!currentProjectPath) {
+      return { success: false, error: 'No project opened' };
+    }
+
+    try {
+      // Find the ALS file in the project
+      const alsResult = await findAlsFile(currentProjectPath);
+      if (!alsResult.success) {
+        return { success: false, error: alsResult.error };
+      }
+
+      // Get the file content from the specified commit
+      const fileResult = await getFileAtCommit(
+        currentProjectPath,
+        commitHash,
+        alsResult.alsPath
+      );
+
+      if (!fileResult.success) {
+        return { success: false, error: fileResult.error };
+      }
+
+      // Parse the ALS content
+      const parseResult = await parseAlsContent(
+        fileResult.content,
+        alsResult.alsName
+      );
+
+      if (!parseResult.success) {
+        return { success: false, error: parseResult.error };
+      }
+
+      return {
+        success: true,
+        data: parseResult.data,
+        commitHash: commitHash
+      };
+    } catch (error) {
+      console.error('Error parsing commit:', error);
+      return { success: false, error: error.message };
+    }
   });
 }
 

--- a/src/main/parser-handler.js
+++ b/src/main/parser-handler.js
@@ -1,0 +1,145 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+/**
+ * Parse ALS XML content using the Python parser.
+ * Pipes the XML content to the parser via stdin and returns parsed JSON.
+ *
+ * @param {string} xmlContent - The decompressed ALS XML content
+ * @param {string} projectName - The project name to include in the output
+ * @returns {Promise<{success: boolean, data?: object, error?: string}>}
+ */
+async function parseAlsContent(xmlContent, projectName = 'Unknown') {
+  return new Promise((resolve) => {
+    // Path to the parser script (relative to project root)
+    const parserPath = path.join(__dirname, '..', '..', 'parser', 'als_parser.py');
+
+    // Spawn Python process
+    const pythonProcess = spawn('python', [parserPath], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    // Collect stdout data
+    pythonProcess.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    // Collect stderr data
+    pythonProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    // Handle process completion
+    pythonProcess.on('close', (code) => {
+      if (code !== 0) {
+        console.error('Parser process exited with code:', code);
+        console.error('Parser stderr:', stderr);
+        resolve({
+          success: false,
+          error: `Parser exited with code ${code}: ${stderr}`
+        });
+        return;
+      }
+
+      try {
+        const parsedData = JSON.parse(stdout);
+        // Override project name if provided
+        if (projectName !== 'Unknown') {
+          parsedData.project_name = projectName;
+        }
+        resolve({
+          success: true,
+          data: parsedData
+        });
+      } catch (parseError) {
+        console.error('Failed to parse JSON output:', parseError);
+        console.error('Raw stdout:', stdout);
+        resolve({
+          success: false,
+          error: `Failed to parse JSON: ${parseError.message}`
+        });
+      }
+    });
+
+    // Handle process errors
+    pythonProcess.on('error', (error) => {
+      console.error('Failed to spawn parser process:', error);
+      resolve({
+        success: false,
+        error: `Failed to spawn parser: ${error.message}`
+      });
+    });
+
+    // Write XML content to stdin and close it
+    pythonProcess.stdin.write(xmlContent);
+    pythonProcess.stdin.end();
+  });
+}
+
+/**
+ * Parse an ALS file directly from disk.
+ *
+ * @param {string} filePath - Path to the .als file
+ * @returns {Promise<{success: boolean, data?: object, error?: string}>}
+ */
+async function parseAlsFile(filePath) {
+  return new Promise((resolve) => {
+    const parserPath = path.join(__dirname, '..', '..', 'parser', 'als_parser.py');
+    const projectName = path.basename(filePath);
+
+    // Spawn Python process with file path argument
+    const pythonProcess = spawn('python', [parserPath, filePath], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    pythonProcess.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    pythonProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    pythonProcess.on('close', (code) => {
+      if (code !== 0) {
+        console.error('Parser process exited with code:', code);
+        console.error('Parser stderr:', stderr);
+        resolve({
+          success: false,
+          error: `Parser exited with code ${code}: ${stderr}`
+        });
+        return;
+      }
+
+      try {
+        const parsedData = JSON.parse(stdout);
+        resolve({
+          success: true,
+          data: parsedData
+        });
+      } catch (parseError) {
+        console.error('Failed to parse JSON output:', parseError);
+        resolve({
+          success: false,
+          error: `Failed to parse JSON: ${parseError.message}`
+        });
+      }
+    });
+
+    pythonProcess.on('error', (error) => {
+      console.error('Failed to spawn parser process:', error);
+      resolve({
+        success: false,
+        error: `Failed to spawn parser: ${error.message}`
+      });
+    });
+  });
+}
+
+module.exports = { parseAlsContent, parseAlsFile };

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -40,6 +40,36 @@ async function handleRestoreClick(event) {
 }
 
 /**
+ * Handle commit click to parse and display ALS data
+ * @param {Event} event - Click event
+ */
+async function handleCommitClick(event) {
+  const commitHash = event.currentTarget.dataset.commitHash;
+
+  if (!commitHash) {
+    console.error('No commit hash found');
+    return;
+  }
+
+  console.log('Parsing commit:', commitHash);
+
+  // Call IPC to parse the ALS file from this commit
+  const result = await ipcRenderer.invoke('parse-commit', commitHash);
+
+  if (result && result.success) {
+    console.log('Parsed ALS data:', result.data);
+    console.log('Project name:', result.data.project_name);
+    console.log('Tempo:', result.data.tempo);
+    console.log('MIDI tracks:', result.data.tracks.midi_tracks.length);
+    console.log('Audio tracks:', result.data.tracks.audio_tracks.length);
+    console.log('Return tracks:', result.data.tracks.return_tracks.length);
+    console.log('Third-party plugins:', result.data.third_party_vsts);
+  } else if (result && !result.success) {
+    console.error('Parse failed:', result.error);
+  }
+}
+
+/**
  * Fetch and display commits from the git repository
  */
 async function loadCommits() {
@@ -56,9 +86,12 @@ async function loadCommits() {
       const commitItem = document.createElement('div');
       commitItem.className = 'commit-item';
 
-      // Commit content (message and metadata)
+      // Commit content (message and metadata) - clickable to parse
       const commitContent = document.createElement('div');
       commitContent.className = 'commit-content';
+      commitContent.style.cursor = 'pointer';
+      commitContent.dataset.commitHash = commit.hash;
+      commitContent.addEventListener('click', handleCommitClick);
 
       const commitMessage = document.createElement('div');
       commitMessage.className = 'commit-message';


### PR DESCRIPTION
This pull request introduces a new feature that enables parsing and extracting detailed project data from Ableton Live Set (.als) files at any git commit, and integrates this functionality throughout the backend and renderer. The changes include significant refactoring of the Python ALS parser to support both file and stdin input, new IPC and handler logic for invoking the parser on historical commits, and new utility functions for locating and reading ALS files from the repository. The renderer is updated to allow users to trigger parsing of ALS files for any commit in the history.

Key changes include:

**Python ALS Parser Enhancements**  
- Refactored `parser/als_parser.py` to support parsing ALS XML from both files and stdin, allowing seamless integration with git history. Added a new `parse_als_to_json` function that outputs a structured JSON summary of the project, including tracks, devices, clips, tempo, and plugins. Improved device and clip extraction logic for greater accuracy and completeness. [[1]](diffhunk://#diff-0aa565630d4aae316d04ef3174872f3ee3a72bcdb573a3881faaf6228c5ca477R2-L23) [[2]](diffhunk://#diff-0aa565630d4aae316d04ef3174872f3ee3a72bcdb573a3881faaf6228c5ca477L101-R255) [[3]](diffhunk://#diff-0aa565630d4aae316d04ef3174872f3ee3a72bcdb573a3881faaf6228c5ca477R307-R353)

**Node.js Backend Integration**  
- Added `parseAlsContent` and `parseAlsFile` functions in `src/main/parser-handler.js` to spawn the Python parser and handle its JSON output, supporting both direct file parsing and stdin-based parsing for historical commits.
- Introduced new utility functions `findAlsFile` and `getFileAtCommit` in `src/main/git-handler.js` to locate the ALS file in a project and retrieve its content from any commit using `git show`.
- Updated IPC handlers in `src/main/ipc-handlers.js` to add a new `parse-commit` channel, which orchestrates finding the ALS file, retrieving its historical content, invoking the parser, and returning the parsed data to the renderer. [[1]](diffhunk://#diff-60ac42fcc255cbf6662f48ddb7a2650bbe6c8ba3d5509b536d99e3a0990c86e0L4-R14) [[2]](diffhunk://#diff-60ac42fcc255cbf6662f48ddb7a2650bbe6c8ba3d5509b536d99e3a0990c86e0R170-R214)

**Renderer/Frontend Integration**  
- Added a new handler in `src/renderer/renderer.js` to allow users to click on a commit and trigger parsing of the ALS file at that commit, logging the parsed project data for further UI integration.

These changes collectively enable users to inspect detailed project structure and metadata for any commit in their Ableton project history, laying the groundwork for advanced version comparison and visualization features.